### PR TITLE
Change Pep517HookCaller to not read pyproject.toml directly

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import os
 from os.path import dirname, abspath, join as pjoin
-import pytoml
 import shutil
 from subprocess import check_call
 import sys
@@ -26,14 +25,11 @@ class Pep517HookCaller(object):
     """A wrapper around a source directory to be built with a PEP 517 backend.
 
     source_dir : The path to the source directory, containing pyproject.toml.
+    backend : The build backend spec, as per PEP 517, from pyproject.toml.
     """
-    def __init__(self, source_dir):
+    def __init__(self, source_dir, build_backend):
         self.source_dir = abspath(source_dir)
-        with open(pjoin(source_dir, 'pyproject.toml')) as f:
-            self.pyproject_data = pytoml.load(f)
-        buildsys = self.pyproject_data['build-system']
-        self.build_sys_requires = buildsys['requires']
-        self.build_backend = buildsys['build-backend']
+        self.build_backend = build_backend
 
     def get_requires_for_build_wheel(self, config_settings):
         """Identify packages required for building a wheel

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -4,6 +4,7 @@ import tarfile
 from testpath import modified_env, assert_isfile, assert_isdir
 from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 import pytest
+import pytoml
 import zipfile
 
 from pep517.wrappers import Pep517HookCaller, UnsupportedOperation
@@ -11,20 +12,26 @@ from pep517.wrappers import Pep517HookCaller, UnsupportedOperation
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
 
+def get_hooks(pkg):
+    source_dir = pjoin(SAMPLES_DIR, pkg)
+    with open(pjoin(source_dir, 'pyproject.toml')) as f:
+        data = pytoml.load(f)
+    return Pep517HookCaller(source_dir, data['build-system']['build-backend'])
+
 def test_get_requires_for_build_wheel():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_wheel({})
     assert res == ['wheelwright']
 
 def test_get_requires_for_build_sdist():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_sdist({})
     assert res == ['frog']
 
 def test_prepare_metadata_for_build_wheel():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with TemporaryDirectory() as metadatadir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             hooks.prepare_metadata_for_build_wheel(metadatadir, {})
@@ -32,7 +39,7 @@ def test_prepare_metadata_for_build_wheel():
         assert_isfile(pjoin(metadatadir, 'pkg1-0.5.dist-info', 'METADATA'))
 
 def test_build_wheel():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with TemporaryDirectory() as builddir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             whl_file = hooks.build_wheel(builddir, {})
@@ -45,7 +52,7 @@ def test_build_wheel():
         assert zipfile.is_zipfile(whl_file)
 
 def test_build_wheel_relpath():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with TemporaryWorkingDirectory() as builddir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             whl_file = hooks.build_wheel('.', {})
@@ -58,7 +65,7 @@ def test_build_wheel_relpath():
         assert zipfile.is_zipfile(whl_file)
 
 def test_build_sdist():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with TemporaryDirectory() as sdistdir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             sdist = hooks.build_sdist(sdistdir, {})
@@ -75,7 +82,7 @@ def test_build_sdist():
         assert 'pkg1-0.5/pyproject.toml' in contents
 
 def test_build_sdist_unsupported():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg1'))
+    hooks = get_hooks('pkg1')
     with TemporaryDirectory() as sdistdir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             with pytest.raises(UnsupportedOperation):

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,4 +1,5 @@
 from os.path import dirname, abspath, join as pjoin
+import pytoml
 from testpath import modified_env, assert_isfile, assert_isdir
 from testpath.tempdir import TemporaryDirectory
 
@@ -7,20 +8,26 @@ from pep517.wrappers import Pep517HookCaller
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
 
+def get_hooks(pkg):
+    source_dir = pjoin(SAMPLES_DIR, pkg)
+    with open(pjoin(source_dir, 'pyproject.toml')) as f:
+        data = pytoml.load(f)
+    return Pep517HookCaller(source_dir, data['build-system']['build-backend'])
+
 def test_get_requires_for_build_wheel():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg2'))
+    hooks = get_hooks('pkg2')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_wheel({})
     assert res == []
 
 def test_get_requires_for_build_sdist():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg2'))
+    hooks = get_hooks('pkg2')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_sdist({})
     assert res == []
 
 def test_prepare_metadata_for_build_wheel():
-    hooks = Pep517HookCaller(pjoin(SAMPLES_DIR, 'pkg2'))
+    hooks = get_hooks('pkg2')
     with TemporaryDirectory() as metadatadir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             hooks.prepare_metadata_for_build_wheel(metadatadir, {})


### PR DESCRIPTION
Modify the low-level wrappers to leave reading of `pyproject.toml` to the caller.

When trying to use the wrappers from pip, the fact that the wrappers do their own parsing and validation of `pyproject.toml` clashes with pip's own parsing and validation. Rather than trying to get the two to work together, it seems to me better to take the approach that it's the caller's responsibility to parse the `pyproject.toml` file, and pass the relevant information (the backend name and the source directory) to the wrappers, rather than have the wrappers try to do two unrelated jobs.

I'm not going to merge this change immediately, as it's a change to the external API, and I'd like some feedback on whether it's OK.