### PR TITLE
Explicitly raise an exception if backend isn't available

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -18,6 +18,9 @@ def tempdir():
     finally:
         shutil.rmtree(td)
 
+class BackendUnavailable(Exception):
+    """Will be raised if the backend cannot be imported in the hook process."""
+
 class UnsupportedOperation(Exception):
     """May be raised by build_sdist if the backend indicates that it can't."""
 
@@ -130,5 +133,7 @@ class Pep517HookCaller(object):
             data = compat.read_json(pjoin(td, 'output.json'))
             if data.get('unsupported'):
                 raise UnsupportedOperation
+            if data.get('no_backend'):
+                raise BackendUnavailable
             return data['return_val']
 

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -7,7 +7,8 @@ import pytest
 import pytoml
 import zipfile
 
-from pep517.wrappers import Pep517HookCaller, UnsupportedOperation
+from pep517.wrappers import Pep517HookCaller
+from pep517.wrappers import UnsupportedOperation, BackendUnavailable
 
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
@@ -17,6 +18,12 @@ def get_hooks(pkg):
     with open(pjoin(source_dir, 'pyproject.toml')) as f:
         data = pytoml.load(f)
     return Pep517HookCaller(source_dir, data['build-system']['build-backend'])
+
+def test_missing_backend_gives_exception():
+    hooks = get_hooks('pkg1')
+    with modified_env({'PYTHONPATH': ''}):
+        with pytest.raises(BackendUnavailable):
+            res = hooks.get_requires_for_build_wheel({})
 
 def test_get_requires_for_build_wheel():
     hooks = get_hooks('pkg1')


### PR DESCRIPTION
A potentially common error will be the user specifying a backend in `pyproject.toml`, but not including the necessary requirements for it. Rather than have that simply result in a generic called subprocess error from the wrapper, we should raise an explicit error for this case, so that front ends can offer a more user-friendly error message explaining the problem.