### PR TITLE
Add build command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,3 +59,7 @@ To build a backend into source and/or binary distributions, run in a shell:
 .. code-block:: shell
 
     python -m pep517.build path/to/source  # source dir containing pyproject.toml
+
+This 'build' module should be considered experimental while the PyPA `decides
+on the best place for this functionality
+<https://github.com/pypa/packaging-problems/issues/219>`_.

--- a/README.rst
+++ b/README.rst
@@ -53,3 +53,9 @@ To test the build backend for a project, run in a system shell:
 .. code-block:: shell
 
     python3 -m pep517.check path/to/source  # source dir containing pyproject.toml
+
+To build a backend into source and/or binary distributions, run in a shell:
+
+.. code-block:: shell
+
+    python -m pep517.build path/to/source  # source dir containing pyproject.toml

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -78,12 +78,12 @@ parser.add_argument(
     help="A directory containing pyproject.toml",
 )
 parser.add_argument(
-    '--binary',
+    '--binary', '-b',
     action='store_true',
     default=False,
 )
 parser.add_argument(
-    '--source',
+    '--source', '-s',
     action='store_true',
     default=False,
 )

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -53,9 +53,9 @@ def mkdir_p(*args, **kwargs):
             raise
 
 
-def build(source_dir, dist):
+def build(source_dir, dist, dest=None):
     pyproject = os.path.join(source_dir, 'pyproject.toml')
-    dest = os.path.join(source_dir, 'dist')
+    dest = os.path.join(source_dir, dest or 'dist')
     mkdir_p(dest)
 
     with open(pyproject) as f:
@@ -87,6 +87,10 @@ parser.add_argument(
     action='store_true',
     default=False,
 )
+parser.add_argument(
+    '--out-dir', '-o',
+    help="Destination in which to save the builds relative to source dir",
+)
 
 
 def main(args):
@@ -97,7 +101,7 @@ def main(args):
     )))
 
     for dist in dists:
-        build(args.source_dir, dist)
+        build(args.source_dir, dist, args.out_dir)
 
 
 if __name__ == '__main__':

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -72,24 +72,24 @@ def build(source_dir, dist):
         _do_build(hooks, env, dist, dest)
 
 
-def main(argv=None):
-    ap = argparse.ArgumentParser()
-    ap.add_argument(
-        'source_dir',
-        help="A directory containing pyproject.toml",
-    )
-    ap.add_argument(
-        '--binary',
-        action='store_true',
-        default=False,
-    )
-    ap.add_argument(
-        '--source',
-        action='store_true',
-        default=False,
-    )
-    args = ap.parse_args(argv)
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'source_dir',
+    help="A directory containing pyproject.toml",
+)
+parser.add_argument(
+    '--binary',
+    action='store_true',
+    default=False,
+)
+parser.add_argument(
+    '--source',
+    action='store_true',
+    default=False,
+)
 
+
+def main(args):
     # determine which dists to build
     dists = list(filter(None, (
         'sdist' if args.source or not args.binary else None,
@@ -101,4 +101,4 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    main()
+    main(parser.parse_args())

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -1,0 +1,104 @@
+"""Build a project using PEP 517 hooks.
+"""
+import argparse
+import logging
+import os
+import contextlib
+import pytoml
+import shutil
+import errno
+import tempfile
+
+from .envbuild import BuildEnvironment
+from .wrappers import Pep517HookCaller
+
+log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def tempdir():
+    td = tempfile.mkdtemp()
+    try:
+        yield td
+    finally:
+        shutil.rmtree(td)
+
+
+def _do_build(hooks, env, dist, dest):
+    get_requires_name = 'get_requires_for_build_{dist}'.format(**locals())
+    get_requires = getattr(hooks, get_requires_name)
+    reqs = get_requires({})
+    log.info('Got build requires: %s', reqs)
+
+    env.pip_install(reqs)
+    log.info('Installed dynamic build dependencies')
+
+    with tempdir() as td:
+        log.info('Trying to build %s in %s', dist, td)
+        build_name = 'build_{dist}'.format(**locals())
+        build = getattr(hooks, build_name)
+        filename = build(td, {})
+        source = os.path.join(td, filename)
+        shutil.move(source, os.path.join(dest, os.path.basename(filename)))
+
+
+def mkdir_p(*args, **kwargs):
+    """Like `mkdir`, but does not raise an exception if the
+    directory already exists.
+    """
+    try:
+        return os.mkdir(*args, **kwargs)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
+
+
+def build(source_dir, dist):
+    pyproject = os.path.join(source_dir, 'pyproject.toml')
+    dest = os.path.join(source_dir, 'dist')
+    mkdir_p(dest)
+
+    with open(pyproject) as f:
+        pyproject_data = pytoml.load(f)
+    # Ensure the mandatory data can be loaded
+    buildsys = pyproject_data['build-system']
+    requires = buildsys['requires']
+    backend = buildsys['build-backend']
+
+    hooks = Pep517HookCaller(source_dir, backend)
+
+    with BuildEnvironment() as env:
+        env.pip_install(requires)
+        _do_build(hooks, env, dist, dest)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        'source_dir',
+        help="A directory containing pyproject.toml",
+    )
+    ap.add_argument(
+        '--binary',
+        action='store_true',
+        default=False,
+    )
+    ap.add_argument(
+        '--source',
+        action='store_true',
+        default=False,
+    )
+    args = ap.parse_args(argv)
+
+    # determine which dists to build
+    dists = list(filter(None, (
+        'sdist' if args.source or not args.binary else None,
+        'wheel' if args.binary or not args.source else None,
+    )))
+
+    for dist in dists:
+        build(args.source_dir, dist)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR introduces `pep517.build`, modeled after `pep517.check`. Fixes #25.

As @pfmoore mentioned in that ticket, the README indicates the experimental nature of this first implementation of a build tool that can build an sdist for PEP 517 projects, and is the first that makes it possible to release some projects without invoking easy_install.