### PR TITLE
Establishes and documents a release process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.3
+commit = True
+tag = True
+
+[bumpversion:file:pep517/__init__.py]

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,9 @@
+To cut a release, use
+`bump2version <https://github.com/c4urself/bump2version>`_,
+the `preferred version
+<https://github.com/peritus/bumpversion/pull/58#issuecomment-428956095>`_
+of bumpversion. Something like:
+
+    bump2version minor
+
+Then push the commit and tags to GitHub.

--- a/pep517/__init__.py
+++ b/pep517/__init__.py
@@ -1,4 +1,4 @@
 """Wrappers to build Python packages using PEP 517 hooks
 """
 
-__version__ = '0.3'
+__version__ = '0.3.0'


### PR DESCRIPTION
These commits add support for using `bumpversion` to automate the process of bumping the project's version and cutting a release. Although I'd prefer to get the version from Git metadata, I don't believe flit supports that, so I'll defer that work for a future effort.

This change does alter the default expectation about tags and version numbers. Instead of N.N, the project now uses the more common N.N.N versioning. bump2version can be configured to support both N.N and N.N.N versions, but doing so is messy and probably not worth it.

Also, the default tags for versions will now be vN.N.N instead of N.N.N, aligning better with the semver convention.