### PR TITLE
Automatically cut releases from tagged commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+sudo: false
 language: python
 
 python:
@@ -24,7 +26,9 @@ jobs:
     - TOXENV=release
     script: tox
 
+cache: pip
+
 install:
-- pip install tox
+- pip install tox tox-venv
 
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,30 @@
 language: python
+
 python:
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
-install: pip install tox
-script: tox -e py
+- &latest_py3 3.6
+- 3.5
+- 3.4
+- 2.7
+
+env:
+- TOXENV=python
+
+jobs:
+  fast_finish: True
+  include:
+  - stage: deploy
+    if: tag IS present
+    python: *latest_py3
+    before_script: skip
+    env:
+    - TWINE_USERNAME=jaraco
+    # TWINE_PASSWORD
+    - secure: g3w+/zzPCeLzZFdDVUj9+bsThzbRyHfVZpoR9Nh1LR7C9CHun6URtplfRl2dp1XHY3pc8YvhiiIllOKuX/5AQRnVhl3eDsAtTcCs4VaAwxF/6MLqnO5rAAviAS8e3O8aW6a9V+5YjSlbWCahfSU+lImf8BTSqIRfvgJNH5cFhDgzPlJociGq9uDQLmNkXVxNoPwAOu6QhpQg68uHs6WvdMBGxHPIQ4cu8l5bUps+6XG0ZMLDKSOjpHFqDO4qih4V8PB8f518UO5hejaaaxV0oOo5hazRtru+Q0xUMVdvVo1egAuU96CZmF6iusNz+0/RGwcspHLnNuvv/h9MBcc7LYkck4KEZmCvvt3yXUxJch3srHfJNUPcpbfOskdB8AlD+MUVnc8sAsx193b5gvm5+vgGpM1srkOwnsKbvv6viDOCT19nZhBLRf6Q3EsazzWlvmI7LgjniGFbr/fstNGN9MVP1lq4eu2V7n5lrg8liSYFNhukhQAYrZstJJnX2BFkipjM79p0gMJGzLIzXET7T5p1EYYvMJTu7Lh9xFfmNH8UKvNsPOcoMPDVgGTgQEzJAVdCnl6XfuKxg6vIwE4X/US2qZHWmVXmgIH9Xmavub6UqyhGL/LdxvE8pXzM+8Vui3Sd/LqjQh3qEuAFQRIOrSO11xod2UfIXNgQyj2Wp+8=
+    - TOX_TESTENV_PASSENV="TWINE_USERNAME TWINE_PASSWORD"
+    - TOXENV=release
+    script: tox
+
+install:
+- pip install tox
+
+script: tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest-flake8
 mock
 testpath
 pytoml
+setuptools>=30

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,18 @@ skipsdist = true
 [testenv]
 deps = -rdev-requirements.txt
 commands = pytest []
+
+[testenv:release]
+skip_install = True
+# workaround for pep517 build support
+install_command = python install-pip-master.py {opts} {packages}
+deps =
+	# pull from feature branch for feature
+	git+https://github.com/pypa/pep517@feature/build-command
+	# workaround for https://github.com/pypa/twine/issues/423
+	git+https://github.com/pypa/twine
+	path.py
+commands =
+	python -c "import path; path.Path('dist').rmtree_p()"
+	python -m pep517.build .
+	python -m twine upload dist/*


### PR DESCRIPTION
This commit adds a new 'job' to the Travis config, one which releases tagged commits, based on work I've done in jaraco/skeleton and which I use in hundreds of other projects to streamline the release process.