### PR TITLE
Proof of Concept: Add support for bootstrap backend

### DIFF
--- a/pep517/_in_process.py
+++ b/pep517/_in_process.py
@@ -29,12 +29,25 @@ class BackendUnavailable(Exception):
         self.traceback = traceback
 
 
+def _backend_importer(mod_path):
+    if mod_path == '<bootstrap-backend>':
+        sys.path.insert(0, '')
+        mod = import_module('__bootstrap_backend__')
+        sys.path[:] = sys.path[1:]
+    else:
+        mod = import_module(mod_path)
+
+    return mod
+
+
 def _build_backend():
     """Find and load the build backend"""
     ep = os.environ['PEP517_BUILD_BACKEND']
+
     mod_path, _, obj_path = ep.partition(':')
+
     try:
-        obj = import_module(mod_path)
+        obj = _backend_importer(mod_path)
     except ImportError:
         raise BackendUnavailable(traceback.format_exc())
     if obj_path:

--- a/tests/samples/bootstrap_pkg/__bootstrap_backend__.py
+++ b/tests/samples/bootstrap_pkg/__bootstrap_backend__.py
@@ -1,0 +1,19 @@
+# A "bootstrap backend" for testing purposes
+def get_requires_for_build_wheel(*args, **kwargs):
+    return ['wheel', 'sentinel']
+
+
+def get_requires_for_build_sdist(*args, **kwargs):
+    return ['sdist_sentinel']
+
+
+def prepare_metadata_for_build_wheel(*args, **kwargs):
+    pass
+
+
+def build_wheel(*args, **kwargs):
+    pass
+
+
+def build_sdist(*args, **kwargs):
+    pass

--- a/tests/samples/bootstrap_pkg/pyproject.toml
+++ b/tests/samples/bootstrap_pkg/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires=[]
+build-backend="<bootstrap-backend>"

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -103,3 +103,13 @@ def test_build_sdist_unsupported():
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
             with pytest.raises(UnsupportedOperation):
                 hooks.build_sdist(sdistdir, {'test_unsupported': True})
+
+
+def test_bootstrap_backend():
+    hooks = get_hooks('bootstrap_pkg')
+    with modified_env({'PYTHONPATH': ''}):
+        wheel_reqs = hooks.get_requires_for_build_wheel({})
+        assert wheel_reqs == ['wheel', 'sentinel']
+
+        sdist_reqs = hooks.get_requires_for_build_sdist({})
+        assert sdist_reqs == ['sdist_sentinel']


### PR DESCRIPTION
As a proof of concept for [a mechanism for bootstrapping PEP 517 backends](https://discuss.python.org/t/pep-517-backend-bootstrapping/789/58?u=pganssle), I've implemented the mechanism where specifying `<bootstrap-backend>` as the `build-backend` triggers an import of `__bootstrap_backend__.py` from the source root.

Obviously we would need agreement that this is the right way to go and an update to the PEP before we could merge this.