### PR TITLE
Tests are run with tox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ provides:
 - Higher-level functions which install the build dependencies into a
   temporary environment and build a wheel/sdist using them.
 
-Run the tests with `tox <https://pypi.org/project/tox>`_.
+Run the tests with ``pytest`` or `tox <https://pypi.org/project/tox>`_.
 
 High level usage, with build requirements handled:
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ provides:
 - Higher-level functions which install the build dependencies into a
   temporary environment and build a wheel/sdist using them.
 
-Run the tests with ``py.test``.
+Run the tests with `tox <https://pypi.org/project/tox>`_.
 
 High level usage, with build requirements handled:
 


### PR DESCRIPTION
I suggest the readme should refer to the more superior mechanism to run tests and link to the project for more info.