### PR TITLE
Add a runner argument to Pep517HookCaller

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -79,8 +79,12 @@ class Pep517HookCaller(object):
     source_dir : The path to the source directory, containing pyproject.toml.
     backend : The build backend spec, as per PEP 517, from pyproject.toml.
     backend_path : The backend path, as per PEP 517, from pyproject.toml.
+    runner : A callable that invokes the wrapper subprocess.
     """
-    def __init__(self, source_dir, build_backend, backend_path=None):
+    def __init__(self, source_dir, build_backend, backend_path=None, runner=None):
+        if runner is None:
+            runner = default_subprocess_runner
+
         self.source_dir = abspath(source_dir)
         self.build_backend = build_backend
         if backend_path:
@@ -88,7 +92,7 @@ class Pep517HookCaller(object):
                 norm_and_check(self.source_dir, p) for p in backend_path
             ]
         self.backend_path = backend_path
-        self._subprocess_runner = default_subprocess_runner
+        self._subprocess_runner = runner
 
     # TODO: Is this over-engineered? Maybe frontends only need to
     #       set this when creating the wrapper, not on every call.

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -81,7 +81,13 @@ class Pep517HookCaller(object):
     backend_path : The backend path, as per PEP 517, from pyproject.toml.
     runner : A callable that invokes the wrapper subprocess.
     """
-    def __init__(self, source_dir, build_backend, backend_path=None, runner=None):
+    def __init__(
+            self,
+            source_dir,
+            build_backend,
+            backend_path=None,
+            runner=None,
+    ):
         if runner is None:
             runner = default_subprocess_runner
 


### PR DESCRIPTION
Toward #13 

pip doesn't really override this on every invocation, and we're currently patching when initializing anyway. This would be an improvement over status quo.

I'd prefer to discuss the context manager support in a follow up PR.
