### PR TITLE
Raise HookMissing instead of falling back, if requested.

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -37,6 +37,9 @@ class BackendInvalid(Exception):
 
 class HookMissing(Exception):
     """Will be raised on missing hooks."""
+    def __init__(self, hook_name):
+        super(HookMissing, self).__init__(hook_name)
+        self.hook_name = hook_name
 
 
 class UnsupportedOperation(Exception):
@@ -245,7 +248,7 @@ class Pep517HookCaller(object):
                     message=data.get('backend_error', '')
                 )
             if data.get('hook_missing'):
-                raise HookMissing()
+                raise HookMissing(hook_name)
             return data['return_val']
 
 

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -35,6 +35,10 @@ class BackendInvalid(Exception):
         self.message = message
 
 
+class HookMissing(Exception):
+    """Will be raised on missing hooks."""
+
+
 class UnsupportedOperation(Exception):
     """May be raised by build_sdist if the backend indicates that it can't."""
     def __init__(self, traceback):
@@ -134,18 +138,21 @@ class Pep517HookCaller(object):
         })
 
     def prepare_metadata_for_build_wheel(
-            self, metadata_directory, config_settings=None):
+            self, metadata_directory, config_settings=None,
+            _allow_fallback=True):
         """Prepare a *.dist-info folder with metadata for this project.
 
         Returns the name of the newly created folder.
 
         If the build backend defines a hook with this name, it will be called
         in a subprocess. If not, the backend will be asked to build a wheel,
-        and the dist-info extracted from that.
+        and the dist-info extracted from that (unless _allow_fallback is
+        False).
         """
         return self._call_hook('prepare_metadata_for_build_wheel', {
             'metadata_directory': abspath(metadata_directory),
             'config_settings': config_settings,
+            '_allow_fallback': _allow_fallback,
         })
 
     def build_wheel(
@@ -237,6 +244,8 @@ class Pep517HookCaller(object):
                     backend_path=self.backend_path,
                     message=data.get('backend_error', '')
                 )
+            if data.get('hook_missing'):
+                raise HookMissing()
             return data['return_val']
 
 

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -45,7 +45,11 @@ def test_prepare_metadata_for_build_wheel_no_fallback():
 
     with TemporaryDirectory() as metadatadir:
         with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
-            with pytest.raises(HookMissing):
+            with pytest.raises(HookMissing) as exc_info:
                 hooks.prepare_metadata_for_build_wheel(
                     metadatadir, {}, _allow_fallback=False
                 )
+
+            e = exc_info.value
+            assert 'prepare_metadata_for_build_wheel' == e.hook_name
+            assert 'prepare_metadata_for_build_wheel' in str(e)

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,9 +1,10 @@
 from os.path import dirname, abspath, join as pjoin
+import pytest
 import pytoml
 from testpath import modified_env, assert_isfile
 from testpath.tempdir import TemporaryDirectory
 
-from pep517.wrappers import Pep517HookCaller
+from pep517.wrappers import HookMissing, Pep517HookCaller
 
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
@@ -37,3 +38,14 @@ def test_prepare_metadata_for_build_wheel():
             hooks.prepare_metadata_for_build_wheel(metadatadir, {})
 
         assert_isfile(pjoin(metadatadir, 'pkg2-0.5.dist-info', 'METADATA'))
+
+
+def test_prepare_metadata_for_build_wheel_no_fallback():
+    hooks = get_hooks('pkg2')
+
+    with TemporaryDirectory() as metadatadir:
+        with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
+            with pytest.raises(HookMissing):
+                hooks.prepare_metadata_for_build_wheel(
+                    metadatadir, {}, _allow_fallback=False
+                )


### PR DESCRIPTION
For now this only applies to `prepare_metadata_for_build_wheel`.

Closes #58.