### PR TITLE
Migrate from pytoml to toml.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,12 @@ available:
 .. code-block:: python
 
     import os
-    import pytoml
+    import toml
     from pep517.wrappers import Pep517HookCaller
 
     src = 'path/to/source'  # Folder containing 'pyproject.toml'
     with open(os.path.join(src, 'pyproject.toml')) as f:
-        build_sys = pytoml.load(f)['build-system']
+        build_sys = toml.load(f)['build-system']
 
     print(build_sys['requires'])  # List of static requirements
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-flake8
 mock
 testpath
-pytoml
+toml
 setuptools>=30
 importlib_metadata
 zipp

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 import os
-import pytoml
+import toml
 import shutil
 
 from .envbuild import BuildEnvironment
@@ -32,7 +32,7 @@ def load_system(source_dir):
     """
     pyproject = os.path.join(source_dir, 'pyproject.toml')
     with open(pyproject) as f:
-        pyproject_data = pytoml.load(f)
+        pyproject_data = toml.load(f)
     return pyproject_data['build-system']
 
 

--- a/pep517/check.py
+++ b/pep517/check.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import os
 from os.path import isfile, join as pjoin
-from pytoml import TomlError, load as toml_load
+from toml import TomlDecodeError, load as toml_load
 import shutil
 from subprocess import CalledProcessError
 import sys
@@ -149,7 +149,7 @@ def check(source_dir):
         backend = buildsys['build-backend']
         backend_path = buildsys.get('backend-path')
         log.info('Loaded pyproject.toml')
-    except (TomlError, KeyError):
+    except (TomlDecodeError, KeyError):
         log.error("Invalid pyproject.toml", exc_info=True)
         return False
 

--- a/pep517/envbuild.py
+++ b/pep517/envbuild.py
@@ -3,7 +3,7 @@
 
 import os
 import logging
-import pytoml
+import toml
 import shutil
 from subprocess import check_call
 import sys
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 def _load_pyproject(source_dir):
     with open(os.path.join(source_dir, 'pyproject.toml')) as f:
-        pyproject_data = pytoml.load(f)
+        pyproject_data = toml.load(f)
     buildsys = pyproject_data['build-system']
     return (
         buildsys['requires'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "thomas@kluyver.me.uk"
 home-page = "https://github.com/takluyver/pep517"
 description-file = "README.rst"
 requires = [
-    "pytoml",
+    "toml",
     "importlib_metadata",
     "zipp",
 ]

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -4,7 +4,7 @@ import tarfile
 from testpath import modified_env, assert_isfile
 from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 import pytest
-import pytoml
+import toml
 import zipfile
 
 from pep517.wrappers import Pep517HookCaller
@@ -17,7 +17,7 @@ BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
 def get_hooks(pkg):
     source_dir = pjoin(SAMPLES_DIR, pkg)
     with open(pjoin(source_dir, 'pyproject.toml')) as f:
-        data = pytoml.load(f)
+        data = toml.load(f)
     return Pep517HookCaller(source_dir, data['build-system']['build-backend'])
 
 

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,6 +1,6 @@
 from os.path import dirname, abspath, join as pjoin
 import pytest
-import pytoml
+import toml
 from testpath import modified_env, assert_isfile
 from testpath.tempdir import TemporaryDirectory
 
@@ -13,7 +13,7 @@ BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
 def get_hooks(pkg):
     source_dir = pjoin(SAMPLES_DIR, pkg)
     with open(pjoin(source_dir, 'pyproject.toml')) as f:
-        data = pytoml.load(f)
+        data = toml.load(f)
     return Pep517HookCaller(source_dir, data['build-system']['build-backend'])
 
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,5 +1,5 @@
 from os.path import dirname, abspath, join as pjoin
-import pytoml
+import toml
 from testpath import modified_env
 import pytest
 
@@ -12,7 +12,7 @@ BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')
 def get_hooks(pkg, backend=None, path=None):
     source_dir = pjoin(SAMPLES_DIR, pkg)
     with open(pjoin(source_dir, 'pyproject.toml')) as f:
-        data = pytoml.load(f)
+        data = toml.load(f)
     if backend is None:
         backend = data['build-system']['build-backend']
     if path is None:


### PR DESCRIPTION
pytoml is unsupported, and is missing recent features of the TOML standard.

Closes #62.