### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,9 @@ requires = [
     "importlib_metadata",
     "zipp",
 ]
-classifiers = ["License :: OSI Approved :: MIT License"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit.buildapi"
 module = "pep517"
 author = "Thomas Kluyver"
 author-email = "thomas@kluyver.me.uk"
-home-page = "https://github.com/takluyver/pep517"
+home-page = "https://github.com/pypa/pep517"
 description-file = "README.rst"
 requires = [
     "toml",


### PR DESCRIPTION
This PR modifies `pyproject.toml` to:

1. Add trove classifiers indicating supported Python versions. This allows automated tools, like PyUp, to verify this information.
2. Update the home-page value, so links are accurate with services like PyPI, PyUp, etc.