### PR TITLE
Drop a no-action-needed TODO

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -126,8 +126,6 @@ class Pep517HookCaller(object):
         self.backend_path = backend_path
         self._subprocess_runner = runner
 
-    # TODO: Is this over-engineered? Maybe frontends only need to
-    #       set this when creating the wrapper, not on every call.
     @contextmanager
     def subprocess_runner(self, runner):
         """A context manager for temporarily overriding the default subprocess


### PR DESCRIPTION
I don't think it's over-engineered.

pip uses three different spinners for different PEP 517 hook calls. We aren't using this API yet but using this would enable a refactor in pip, that'll help remove a bunch of state only maintained for the hook-specific spinners.

(I'm currently refactoring pip's build logic, so I've finally had enough understanding of the hook calling code, to comment on this)