### PR TITLE
Don't pull in importlib_metadata & zipp backports for Python 3.8+

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,5 @@ mock
 testpath
 toml
 setuptools>=30
-importlib_metadata
-zipp
+importlib_metadata ; python_version<'3.8'
+zipp ; python_version<'3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ home-page = "https://github.com/pypa/pep517"
 description-file = "README.rst"
 requires = [
     "toml",
-    "importlib_metadata",
-    "zipp",
+    "importlib_metadata;python_version<'3.8'",
+    "zipp;python_version<'3.8'",
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The Python 3.8+ standard library `importlib.metadata` and `zipfile.Path` are [preferred over the backports](https://github.com/pypa/pep517/blob/master/pep517/meta.py#L9-L17).

(FWIW: Fedora doesn't have the backports packaged for 3.8, but we use the wheel metadata, so things go [boom!](https://bugzilla.redhat.com/show_bug.cgi?id=1770845) I'm sharing the patch – less dependencies is always good, right?)
