### PR TITLE
Update CI to Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: python
 
 python:
-- &latest_py3 3.7
+- &latest_py3 3.8
+- 3.7
 - 3.6
 - 3.5
 - 3.4


### PR DESCRIPTION
`latest_py3` should now be 3.8 :tada: 

I hope this is the right way to tell it to Travis.