### PR TITLE
Allow to specify the isolated build environment

### DIFF
--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -115,8 +115,8 @@ class Pep517HookCaller(object):
     build_backend : The build backend spec, as per PEP 517, from
         pyproject.toml.
     backend_path : The backend path, as per PEP 517, from pyproject.toml.
-    executable: The path to the isolated python executable to run within
     runner : A callable that invokes the wrapper subprocess.
+    executable: The path to the isolated python executable to run within
 
     The 'runner', if provided, must expect the following:
         cmd : a list of strings representing the command and arguments to

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -115,6 +115,7 @@ class Pep517HookCaller(object):
     build_backend : The build backend spec, as per PEP 517, from
         pyproject.toml.
     backend_path : The backend path, as per PEP 517, from pyproject.toml.
+    executable: The path to the isolated python executable to run within
     runner : A callable that invokes the wrapper subprocess.
 
     The 'runner', if provided, must expect the following:
@@ -131,6 +132,7 @@ class Pep517HookCaller(object):
             build_backend,
             backend_path=None,
             runner=None,
+            executable=sys.executable,
     ):
         if runner is None:
             runner = default_subprocess_runner
@@ -143,6 +145,7 @@ class Pep517HookCaller(object):
             ]
         self.backend_path = backend_path
         self._subprocess_runner = runner
+        self.executable = executable
 
     @contextmanager
     def subprocess_runner(self, runner):
@@ -262,7 +265,7 @@ class Pep517HookCaller(object):
             # Run the hook in a subprocess
             with _in_proc_script_path() as script:
                 self._subprocess_runner(
-                    [sys.executable, str(script), hook_name, td],
+                    [self.executable, str(script), hook_name, td],
                     cwd=self.source_dir,
                     extra_environ=extra_environ
                 )


### PR DESCRIPTION
Before always defaulted to the current python executable, however if the
isolated build environment was a virtual environment this might not be
the case.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

Ran into this while doing https://github.com/FFY00/python-build