### PR TITLE
Don't specify dist & sudo in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-sudo: false
 language: python
 
 python:


### PR DESCRIPTION
I don't think these are necessary any more.