### PR TITLE
Allow building with Flit 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
Contents of the wheels I got from `pip wheel .` before and after this commit are identical, except `Generator` metadata and associated hash:

<details>
<summary>diff</summary>

```diff
--- _pre/pep517-0.9.1.dist-info/RECORD	2016-01-01 00:00:00.000000000 +0100
+++ _post/pep517-0.9.1.dist-info/RECORD	2016-01-01 00:00:00.000000000 +0100
@@ -10,5 +10,5 @@
 pep517/wrappers.py,sha256=JSGCGAmbp90tlx3-di3i-Qvrdgi4o8VhIsJPvuJg7uA,11290
 pep517-0.9.1.dist-info/LICENSE,sha256=GyKwSbUmfW38I6Z79KhNjsBLn9-xpR02DkK0NCyLQVQ,1081
-pep517-0.9.1.dist-info/WHEEL,sha256=4vGQWMHJO3SOyvYcLHqr380W2n90FCfzkrP_YY3xjq8,99
+pep517-0.9.1.dist-info/WHEEL,sha256=NLqmsx-ZFZ6gDavYgh2oH0ZSN-KRmpcdEXIZDnYy9Pg,99
 pep517-0.9.1.dist-info/METADATA,sha256=ggOOAr8j780oE0Qlmz5IcLvk1IhCOxpPwdbtTtx3Ye0,3620
 pep517-0.9.1.dist-info/RECORD,,
diff -rU2 _pre/pep517-0.9.1.dist-info/WHEEL _post/pep517-0.9.1.dist-info/WHEEL
--- _pre/pep517-0.9.1.dist-info/WHEEL	2016-01-01 00:00:00.000000000 +0100
+++ _post/pep517-0.9.1.dist-info/WHEEL	2016-01-01 00:00:00.000000000 +0100
@@ -1,4 +1,4 @@
 Wheel-Version: 1.0
-Generator: flit 2.3.0
+Generator: flit 3.0.0
 Root-Is-Purelib: true
 Tag: py2-none-any
```

</details>