### PR TITLE
tests: remove dependency on mock for python3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-flake8
-mock
+mock ; python_version<'3.6'
 testpath
 toml
 setuptools>=30

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -8,7 +8,10 @@ import toml
 import zipfile
 import sys
 
-from mock import Mock
+try:
+    from mock import Mock  # Prefer the backport below python 3.6
+except ImportError:
+    from unittest.mock import Mock
 
 from pep517.wrappers import Pep517HookCaller, default_subprocess_runner
 from pep517.wrappers import UnsupportedOperation, BackendUnavailable


### PR DESCRIPTION
Sometimes it was imported as unittest.mock, sometimes as mock. Consistently stick to the former.