### PR TITLE
Add a test for setup.py support

### DIFF
--- a/tests/samples/setup-py/pyproject.toml
+++ b/tests/samples/setup-py/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/samples/setup-py/setup.py
+++ b/tests/samples/setup-py/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+setup(
+    name='pep517-test-setup-py-support',
+    version='1.0'
+)

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -171,3 +171,10 @@ def test_issue_104():
         '__init__.py', '__init__.pyc', '_in_process.py', '_in_process.pyc',
         '__pycache__',
     }
+
+
+def test_setup_py():
+    hooks = get_hooks('setup-py')
+    with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
+        res = hooks.get_requires_for_build_wheel({})
+    assert res == ['wheel']

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -177,4 +177,5 @@ def test_setup_py():
     hooks = get_hooks('setup-py')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_wheel({})
+    res = [x for x in res if x != 'setuptools']
     assert res == ['wheel']

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -177,5 +177,6 @@ def test_setup_py():
     hooks = get_hooks('setup-py')
     with modified_env({'PYTHONPATH': BUILDSYS_PKGS}):
         res = hooks.get_requires_for_build_wheel({})
+    # Some versions of setuptools list setuptools itself here
     res = [x for x in res if x != 'setuptools']
     assert res == ['wheel']


### PR DESCRIPTION
It looks like you did not have a test for setup.py support. Now you do. Note: this will unfortunately cause conflicts with #105. After one of the two PRs is merged I'll rebase the other.