### PR TITLE
Deprecate the high level interface

### DIFF
--- a/pep517/build.py
+++ b/pep517/build.py
@@ -110,6 +110,8 @@ parser.add_argument(
 
 
 def main(args):
+    log.warning('pep517.build is deprecated. Consider switching to https://pypi.org/project/build/')
+
     # determine which dists to build
     dists = list(filter(None, (
         'sdist' if args.source or not args.binary else None,

--- a/pep517/check.py
+++ b/pep517/check.py
@@ -167,6 +167,8 @@ def check(source_dir):
 
 
 def main(argv=None):
+    log.warning('pep517.check is deprecated. Consider switching to https://pypi.org/project/build/')
+
     ap = argparse.ArgumentParser()
     ap.add_argument(
         'source_dir',


### PR DESCRIPTION
 #91

> Add a deprecation warning when pep517.build is used
> Add a deprecation warning when pep517.checkis used