### PR TITLE
Clarify the issue template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,4 +1,4 @@
 <!--
-Note that pep517.build and pep517.check are frozen (we stopped improving them) and will eventually be deprecated.
+Note that the CLI tools pep517.build and pep517.check are frozen (we stopped improving them) and will eventually be deprecated.
 All improvements should go to https://github.com/pypa/build
 -->


### PR DESCRIPTION
The way the issue template is currently worded someone unfamiliar with the project may think the entire project is deprecated instead of just the CLI tools pep517.build and pep517.check. This PR clarifies the confusion.