### PR TITLE
compat: fallback to toml if tomli is not available

### DIFF
--- a/pep517/compat.py
+++ b/pep517/compat.py
@@ -35,7 +35,10 @@ except NameError:
     FileNotFoundError = IOError
 
 
-if sys.version_info < (3, 6):
+try:
+    from tomli import load as toml_load  # noqa: F401
+    from tomli import TOMLDecodeError  # noqa: F401
+except ImportError:
     from toml import load as _toml_load  # noqa: F401
 
     def toml_load(f):
@@ -46,6 +49,3 @@ if sys.version_info < (3, 6):
             w.detach()
 
     from toml import TomlDecodeError as TOMLDecodeError  # noqa: F401
-else:
-    from tomli import load as toml_load  # noqa: F401
-    from tomli import TOMLDecodeError  # noqa: F401


### PR DESCRIPTION
We already have the code, as we support Python < 3.6, and being able to
fallback to toml if tomli is not available will make bootstraping Python
environments much easier.

Signed-off-by: Filipe Laíns <lains@riseup.net>