### PR TITLE
Use isort to automatically sort Python imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,23 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+  isort:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install Tox
+      run: |
+        pip install tox tox-venv
+
+    - name: Run tests
+      run: tox -e isort
+
   tests:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -6,10 +6,10 @@ import logging
 import os
 import shutil
 
+from .compat import FileNotFoundError, toml_load
+from .dirtools import mkdir_p, tempdir
 from .envbuild import BuildEnvironment
 from .wrappers import Pep517HookCaller
-from .dirtools import tempdir, mkdir_p
-from .compat import FileNotFoundError, toml_load
 
 log = logging.getLogger(__name__)
 

--- a/pep517/check.py
+++ b/pep517/check.py
@@ -4,13 +4,14 @@ import argparse
 import io
 import logging
 import os
-from os.path import isfile, join as pjoin
 import shutil
-from subprocess import CalledProcessError
 import sys
 import tarfile
-from tempfile import mkdtemp
 import zipfile
+from os.path import isfile
+from os.path import join as pjoin
+from subprocess import CalledProcessError
+from tempfile import mkdtemp
 
 from .colorlog import enable_colourful_output
 from .compat import TOMLDecodeError, toml_load

--- a/pep517/compat.py
+++ b/pep517/compat.py
@@ -3,7 +3,6 @@ import io
 import json
 import sys
 
-
 # Handle reading and writing JSON in UTF-8, on Python 3 and 2.
 
 if sys.version_info[0] >= 3:
@@ -47,5 +46,5 @@ if sys.version_info < (3, 6):
 
     from toml import TomlDecodeError as TOMLDecodeError  # noqa: F401
 else:
-    from tomli import load as toml_load  # noqa: F401
     from tomli import TOMLDecodeError  # noqa: F401
+    from tomli import load as toml_load  # noqa: F401

--- a/pep517/dirtools.py
+++ b/pep517/dirtools.py
@@ -1,9 +1,9 @@
-import os
-import io
 import contextlib
-import tempfile
-import shutil
 import errno
+import io
+import os
+import shutil
+import tempfile
 import zipfile
 
 

--- a/pep517/envbuild.py
+++ b/pep517/envbuild.py
@@ -2,16 +2,16 @@
 """
 
 import io
-import os
 import logging
+import os
 import shutil
-from subprocess import check_call
 import sys
+from subprocess import check_call
 from sysconfig import get_paths
 from tempfile import mkdtemp
 
 from .compat import toml_load
-from .wrappers import Pep517HookCaller, LoggerWrapper
+from .wrappers import LoggerWrapper, Pep517HookCaller
 
 log = logging.getLogger(__name__)
 

--- a/pep517/in_process/__init__.py
+++ b/pep517/in_process/__init__.py
@@ -3,8 +3,9 @@
 The subpackage should stay as empty as possible to avoid shadowing modules that
 the backend might import.
 """
-from os.path import dirname, abspath, join as pjoin
 from contextlib import contextmanager
+from os.path import abspath, dirname
+from os.path import join as pjoin
 
 try:
     import importlib.resources as resources

--- a/pep517/in_process/_in_process.py
+++ b/pep517/in_process/_in_process.py
@@ -12,16 +12,16 @@ Results:
 - control_dir/output.json
   - {"return_val": ...}
 """
-from glob import glob
-from importlib import import_module
 import json
 import os
 import os.path
-from os.path import join as pjoin
 import re
 import shutil
 import sys
 import traceback
+from glob import glob
+from importlib import import_module
+from os.path import join as pjoin
 
 # This file is run as a script, and `import compat` is not zip-safe, so we
 # include write_json() and read_json() from compat.py.

--- a/pep517/meta.py
+++ b/pep517/meta.py
@@ -1,10 +1,10 @@
 """Build metadata for a project using PEP 517 hooks.
 """
 import argparse
+import functools
 import logging
 import os
 import shutil
-import functools
 
 try:
     import importlib.metadata as imp_meta
@@ -16,10 +16,10 @@ try:
 except ImportError:
     from zipp import Path
 
+from .build import compat_system, load_system, validate_system
+from .dirtools import dir_to_zipfile, mkdir_p, tempdir
 from .envbuild import BuildEnvironment
 from .wrappers import Pep517HookCaller, quiet_subprocess_runner
-from .dirtools import tempdir, mkdir_p, dir_to_zipfile
-from .build import validate_system, load_system, compat_system
 
 log = logging.getLogger(__name__)
 

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -1,10 +1,11 @@
+import os
+import shutil
+import sys
 import threading
 from contextlib import contextmanager
-import os
-from os.path import abspath, join as pjoin
-import shutil
-from subprocess import check_call, check_output, STDOUT
-import sys
+from os.path import abspath
+from os.path import join as pjoin
+from subprocess import STDOUT, check_call, check_output
 from tempfile import mkdtemp
 
 from . import compat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
 ]
+
+[tool.isort]
+profile = "black"

--- a/tests/samples/buildsys_pkgs/buildsys.py
+++ b/tests/samples/buildsys_pkgs/buildsys.py
@@ -3,10 +3,10 @@
 Don't use this for any real code.
 """
 
-from glob import glob
-from os.path import join as pjoin
 import shutil
 import tarfile
+from glob import glob
+from os.path import join as pjoin
 from zipfile import ZipFile
 
 

--- a/tests/samples/buildsys_pkgs/buildsys_minimal.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal.py
@@ -2,9 +2,9 @@
 
 Don't use this for any real code.
 """
+import tarfile
 from glob import glob
 from os.path import join as pjoin
-import tarfile
 from zipfile import ZipFile
 
 

--- a/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
@@ -1,4 +1,3 @@
 from buildsys_minimal import build_sdist, build_wheel  # noqa
 
-
 build_editable = build_wheel

--- a/tests/samples/test-for-issue-104/setup.py
+++ b/tests/samples/test-for-issue-104/setup.py
@@ -1,7 +1,8 @@
-import sys
-from setuptools import setup
-from os import path, environ, listdir
 import json
+import sys
+from os import environ, listdir, path
+
+from setuptools import setup
 
 children = listdir(sys.path[0])
 out = path.join(environ['PEP517_ISSUE104_OUTDIR'], 'out.json')

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -1,13 +1,15 @@
 import io
-import os
-from os.path import dirname, abspath, join as pjoin
-import tarfile
-from testpath import modified_env, assert_isfile
-from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
-import pytest
-import zipfile
-import sys
 import json
+import os
+import sys
+import tarfile
+import zipfile
+from os.path import abspath, dirname
+from os.path import join as pjoin
+
+import pytest
+from testpath import assert_isfile, modified_env
+from testpath.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 
 try:
     from mock import Mock  # Prefer the backport below python 3.6
@@ -15,9 +17,12 @@ except ImportError:
     from unittest.mock import Mock
 
 from pep517.compat import toml_load
-from pep517.wrappers import Pep517HookCaller, default_subprocess_runner
-from pep517.wrappers import UnsupportedOperation, BackendUnavailable
-
+from pep517.wrappers import (
+    BackendUnavailable,
+    Pep517HookCaller,
+    UnsupportedOperation,
+    default_subprocess_runner,
+)
 
 if sys.version_info[0] == 2:
     FileNotFoundError = IOError

--- a/tests/test_envbuild.py
+++ b/tests/test_envbuild.py
@@ -1,14 +1,18 @@
-from os.path import dirname, abspath, join as pjoin
 import tarfile
-from testpath import modified_env, assert_isfile
+from os.path import abspath, dirname
+from os.path import join as pjoin
+
+from testpath import assert_isfile, modified_env
 from testpath.tempdir import TemporaryDirectory
+
 try:
-    from unittest.mock import patch, call
+    from unittest.mock import call, patch
 except ImportError:
     from mock import patch, call  # Python 2 fallback
+
 import zipfile
 
-from pep517.envbuild import build_sdist, build_wheel, BuildEnvironment
+from pep517.envbuild import BuildEnvironment, build_sdist, build_wheel
 
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,7 +1,9 @@
 import io
-from os.path import dirname, abspath, join as pjoin
+from os.path import abspath, dirname
+from os.path import join as pjoin
+
 import pytest
-from testpath import modified_env, assert_isfile
+from testpath import assert_isfile, modified_env
 from testpath.tempdir import TemporaryDirectory
 
 from pep517.compat import toml_load

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,10 +1,12 @@
 import io
-from os.path import dirname, abspath, join as pjoin
-from testpath import modified_env
+from os.path import abspath, dirname
+from os.path import join as pjoin
+
 import pytest
+from testpath import modified_env
 
 from pep517.compat import toml_load
-from pep517.wrappers import Pep517HookCaller, BackendInvalid
+from pep517.wrappers import BackendInvalid, Pep517HookCaller
 
 SAMPLES_DIR = pjoin(dirname(abspath(__file__)), 'samples')
 BUILDSYS_PKGS = pjoin(SAMPLES_DIR, 'buildsys_pkgs')

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,11 +1,10 @@
-from __future__ import unicode_literals, absolute_import, division
+from __future__ import absolute_import, division, unicode_literals
 
 import re
 
 import pytest
 
 from pep517 import meta
-
 
 pep517_needs_python_3 = pytest.mark.xfail(
     'sys.version_info < (3,)',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, py39, py310, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, py38, py39, py310, pypy, pypy3, isort
 skipsdist = true
 
 [testenv]
 deps = -rdev-requirements.txt
 commands = pytest []
+
+[testenv:isort]
+deps = isort
+commands = python -m isort --check --diff {toxinidir}
 
 [testenv:release]
 skip_install = True


### PR DESCRIPTION
isort is a Python utility to sort imports alphabetically by section. It
improves the contributor experience by catching style concerns early in
CI rather than during a review. When CI fails, the contributor can use
the tool to apply changes automatically.

isort is very popular and used by big Python projects such as pip.

https://pycqa.github.io/isort/