### PR TITLE
Enfoce https://reuse.software compliance

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+;
+; SPDX-License-Identifier: MIT
+
 [bumpversion]
 current_version = 0.12.0
 commit = True

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Copied from https://github.com/fsfe/reuse-action#example-usage
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: 
+    - uses: actions/checkout@v2
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 name: Tests
 
 on: [push, pull_request]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 __pycache__/
 *.pyc
 /dist/

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+..
+.. SPDX-License-Identifier: MIT
+
 API to call PEP 517 hooks
 =========================
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+..
+.. SPDX-License-Identifier: MIT
+
 To cut a release, use
 `bump2version <https://github.com/c4urself/bump2version>`_,
 the `preferred version

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 pytest
 pytest-flake8
 flake8 < 4  # https://github.com/tholo/pytest-flake8/issues/81

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@
 
 pytest
 pytest-flake8
-flake8 < 4  # https://github.com/tholo/pytest-flake8/issues/81
+flake8
 testpath
 tomli
 setuptools>=30

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/doc/callhooks.rst
+++ b/doc/callhooks.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+..
+.. SPDX-License-Identifier: MIT
+
 API reference
 =============
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+..
+.. SPDX-License-Identifier: MIT
+
 Changelog
 =========
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+..
+.. SPDX-License-Identifier: MIT
+
 pep517
 ======
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,3 +1,7 @@
+REM SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+REM
+REM SPDX-License-Identifier: MIT
+
 @ECHO OFF
 
 pushd %~dp0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 tomli

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,4 +1,10 @@
 <!--
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+<!--
 Note that the CLI tools pep517.build and pep517.check are frozen (we stopped improving them) and will eventually be deprecated.
 All improvements should go to https://github.com/pypa/build
 -->

--- a/pep517/__init__.py
+++ b/pep517/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Wrappers to build Python packages using PEP 517 hooks
 """
 

--- a/pep517/__init__.py
+++ b/pep517/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Build a project using PEP 517 hooks.
 """
 import argparse

--- a/pep517/build.py
+++ b/pep517/build.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/check.py
+++ b/pep517/check.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Check a project and backend by attempting to build using PEP 517 hooks.
 """
 import argparse

--- a/pep517/check.py
+++ b/pep517/check.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/colorlog.py
+++ b/pep517/colorlog.py
@@ -4,6 +4,8 @@ Code copied from Tornado, Apache licensed.
 """
 # Copyright 2012 Facebook
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at

--- a/pep517/dirtools.py
+++ b/pep517/dirtools.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import io
 import os
 import zipfile

--- a/pep517/dirtools.py
+++ b/pep517/dirtools.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/envbuild.py
+++ b/pep517/envbuild.py
@@ -1,6 +1,10 @@
 """Build wheels/sdists by installing build deps to a temporary environment.
 """
 
+# Copyright (c) 2008-2016 The pip developers (see AUTHORS.txt file)
+#
+# SPDX-License-Identifier: MIT
+
 import logging
 import os
 import shutil

--- a/pep517/in_process/__init__.py
+++ b/pep517/in_process/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/in_process/__init__.py
+++ b/pep517/in_process/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """This is a subpackage because the directory is on sys.path for _in_process.py
 
 The subpackage should stay as empty as possible to avoid shadowing modules that

--- a/pep517/in_process/_in_process.py
+++ b/pep517/in_process/_in_process.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/in_process/_in_process.py
+++ b/pep517/in_process/_in_process.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """This is invoked in a subprocess to call the build backend hooks.
 
 It expects:

--- a/pep517/meta.py
+++ b/pep517/meta.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Build metadata for a project using PEP 517 hooks.
 """
 import argparse

--- a/pep517/meta.py
+++ b/pep517/meta.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/pep517/wrappers.py
+++ b/pep517/wrappers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+;
+; SPDX-License-Identifier: MIT
+
 [pytest]
 addopts =
     --strict-config

--- a/tests/samples/buildsys_pkgs/buildsys.py
+++ b/tests/samples/buildsys_pkgs/buildsys.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/buildsys_pkgs/buildsys.py
+++ b/tests/samples/buildsys_pkgs/buildsys.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """This is a very stupid backend for testing purposes.
 
 Don't use this for any real code.

--- a/tests/samples/buildsys_pkgs/buildsys_minimal.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/buildsys_pkgs/buildsys_minimal.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Test backend defining only the mandatory hooks.
 
 Don't use this for any real code.

--- a/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 from buildsys_minimal import build_sdist, build_wheel  # noqa
 
 build_editable = build_wheel

--- a/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
+++ b/tests/samples/buildsys_pkgs/buildsys_minimal_editable.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/pkg1/pkg1-0.5.dist-info/METADATA.license
+++ b/tests/samples/pkg1/pkg1-0.5.dist-info/METADATA.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg1/pkg1-0.5.dist-info/RECORD.license
+++ b/tests/samples/pkg1/pkg1-0.5.dist-info/RECORD.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg1/pkg1-0.5.dist-info/WHEEL.license
+++ b/tests/samples/pkg1/pkg1-0.5.dist-info/WHEEL.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg1/pkg1.py
+++ b/tests/samples/pkg1/pkg1.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Sample package for tests"""
 
 __version__ = '0.5'

--- a/tests/samples/pkg1/pkg1.py
+++ b/tests/samples/pkg1/pkg1.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/pkg1/pyproject.toml
+++ b/tests/samples/pkg1/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = ["eg_buildsys"]
 build-backend = "buildsys"

--- a/tests/samples/pkg2/pkg2-0.5.dist-info/METADATA.license
+++ b/tests/samples/pkg2/pkg2-0.5.dist-info/METADATA.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg2/pkg2-0.5.dist-info/RECORD.license
+++ b/tests/samples/pkg2/pkg2-0.5.dist-info/RECORD.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg2/pkg2-0.5.dist-info/WHEEL.license
+++ b/tests/samples/pkg2/pkg2-0.5.dist-info/WHEEL.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg2/pkg2.py
+++ b/tests/samples/pkg2/pkg2.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Sample package for tests"""
 
 __version__ = '0.5'

--- a/tests/samples/pkg2/pkg2.py
+++ b/tests/samples/pkg2/pkg2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/pkg2/pyproject.toml
+++ b/tests/samples/pkg2/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = []
 build-backend = "buildsys_minimal"

--- a/tests/samples/pkg3/pkg3-0.5.dist-info/METADATA.license
+++ b/tests/samples/pkg3/pkg3-0.5.dist-info/METADATA.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg3/pkg3-0.5.dist-info/RECORD.license
+++ b/tests/samples/pkg3/pkg3-0.5.dist-info/RECORD.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg3/pkg3-0.5.dist-info/WHEEL.license
+++ b/tests/samples/pkg3/pkg3-0.5.dist-info/WHEEL.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+
+SPDX-License-Identifier: MIT

--- a/tests/samples/pkg3/pkg3.py
+++ b/tests/samples/pkg3/pkg3.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 """Sample package for tests"""
 
 __version__ = '0.5'

--- a/tests/samples/pkg3/pkg3.py
+++ b/tests/samples/pkg3/pkg3.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/pkg3/pyproject.toml
+++ b/tests/samples/pkg3/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = []
 build-backend = "buildsys_minimal_editable"

--- a/tests/samples/pkg_intree/backend/intree_backend.py
+++ b/tests/samples/pkg_intree/backend/intree_backend.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/pkg_intree/backend/intree_backend.py
+++ b/tests/samples/pkg_intree/backend/intree_backend.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 def get_requires_for_build_sdist(config_settings):
     return ["intree_backend_called"]

--- a/tests/samples/pkg_intree/pyproject.toml
+++ b/tests/samples/pkg_intree/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 build-backend = 'intree_backend'
 backend-path = ['backend']

--- a/tests/samples/setup-py/pyproject.toml
+++ b/tests/samples/setup-py/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tests/samples/setup-py/setup.py
+++ b/tests/samples/setup-py/setup.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/setup-py/setup.py
+++ b/tests/samples/setup-py/setup.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 from setuptools import setup
 
 setup(

--- a/tests/samples/test-for-issue-104/pyproject.toml
+++ b/tests/samples/test-for-issue-104/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tests/samples/test-for-issue-104/setup.py
+++ b/tests/samples/test-for-issue-104/setup.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/samples/test-for-issue-104/setup.py
+++ b/tests/samples/test-for-issue-104/setup.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import sys
 from os import environ, listdir, path

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import pytest
 
 from pep517 import build

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_call_hooks.py
+++ b/tests/test_call_hooks.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import json
 import os
 import tarfile

--- a/tests/test_envbuild.py
+++ b/tests/test_envbuild.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_envbuild.py
+++ b/tests/test_envbuild.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import tarfile
 import zipfile
 from os.path import abspath, dirname

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 from os.path import abspath, dirname
 from os.path import join as pjoin
 

--- a/tests/test_hook_fallbacks.py
+++ b/tests/test_hook_fallbacks.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 from os.path import abspath, dirname
 from os.path import join as pjoin
 

--- a/tests/test_inplace_hooks.py
+++ b/tests/test_inplace_hooks.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+#
+# SPDX-License-Identifier: MIT
+
 import re
 
 from pep517 import meta

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+# SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors  # noqa: E501
 #
 # SPDX-License-Identifier: MIT
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2017-2021 Thomas Kluyver <thomas@kluyver.me.uk> and other contributors
+;
+; SPDX-License-Identifier: MIT
+
 [tox]
 envlist = py36, py37, py38, py39, py310, pypy3, isort
 skipsdist = true


### PR DESCRIPTION
The https://reuse.software specification is the standard for providing machine-readable licensing and copyright information.

I believe:
* machine-readable metadata is a good thing.
* licensing and copyright matter
* automation is a good thing.

Therefore I propose we:
1. Make this repository compliant with the https://reuse.software specification
2. Enfoce compliance via a github action