### PR TITLE
Run flake8 static checks separately from test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  isort:
+  static-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +23,7 @@ jobs:
         pip install tox tox-venv
 
     - name: Run tests
-      run: tox -e isort
+      run: tox -e isort,flake8
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 pytest
-pytest-flake8
 flake8
 testpath
 tomli

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,10 +2,7 @@
 addopts =
     --strict-config
     --strict-markers
-    --flake8
 xfail_strict = True
 junit_family = xunit2
 filterwarnings =
     error
-    # Suppress deprecation warning in flake8
-    ignore:SelectableGroups dict interface is deprecated::flake8

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ commands = pytest []
 deps = isort
 commands = python -m isort --check --diff {toxinidir}
 
+[testenv:flake8]
+deps = flake8
+commands = flake8 pep517
+
 [testenv:release]
 skip_install = True
 deps =


### PR DESCRIPTION
pytest-flake8 is a compatibility headache - see https://github.com/tholo/pytest-flake8/issues/81 https://github.com/tholo/pytest-flake8/issues/83 & https://github.com/tholo/pytest-flake8/issues/87 . The advantages of running it inside pytest seem small at best, so this gets rid of the pytest integration in favour of running `flake8` directly. In the CI, isort & flake8 are run as part of a 'static-checks' job.