### PR TITLE
Use os.path.commonpath() instead of commonprefix()

### DIFF
--- a/src/pyproject_hooks/_impl.py
+++ b/src/pyproject_hooks/_impl.py
@@ -117,12 +117,9 @@ def norm_and_check(source_tree: str, requested: str) -> str:
 
     abs_source = os.path.abspath(source_tree)
     abs_requested = os.path.normpath(os.path.join(abs_source, requested))
-    # We have to use commonprefix for Python 2.7 compatibility. So we
-    # normalise case to avoid problems because commonprefix is a character
-    # based comparison :-(
     norm_source = os.path.normcase(abs_source)
     norm_requested = os.path.normcase(abs_requested)
-    if os.path.commonprefix([norm_source, norm_requested]) != norm_source:
+    if os.path.commonpath([norm_source, norm_requested]) != norm_source:
         raise ValueError("paths must be inside source tree")
 
     return abs_requested


### PR DESCRIPTION
Now that `pyproject-hooks` supports only Python 3.6+ `commonprefix()` is no longer required.