### PR TITLE
docs: add SECURITY.md reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release line on a best-effort basis.
+
+## Reporting a Vulnerability
+
+Please report security issues privately via GitHub Security Advisories for this
+repository:
+
+https://github.com/pypa/pyproject-hooks/security/advisories/new
+
+Do **not** open a public issue for vulnerabilities that could put users at risk.
+
+We will acknowledge the report and work with you on a coordinated disclosure.


### PR DESCRIPTION
## Summary
Add `SECURITY.md` describing private vulnerability reporting via GitHub Security Advisories (issue #228).

Fixes #228
